### PR TITLE
node script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hook scripts plugin for Serverless
 Kenneth Falck <kennu@iki.fi> 2016
 
-This plugin lets you easily create shell script hooks that are run whenever
+This plugin lets you easily create shell or node script hooks that are run whenever
 Serverless actions are executed.
 
 ## Installation
@@ -22,12 +22,13 @@ the plugin as follows:
 Use the "hookscripts create" command to create sample hook scripts in the *s-hooks*
 folder of your project root.
 
-To enable a hook, remove the ".sample" extension of the generated script.
+To enable a shell script hook, remove the ".sample" extension of the generated script.
+To enable a node script hook, create a .js file that exports a function handler for the hook.
 
 To understand all the hooks, you may need to refer to the Serverless source code
 at https://github.com/serverless/serverless/tree/master/lib/actions.
 
-## Event data
+## Shell Script: Event data
 
 The data in event.options is made available to the shell scripts in two ways:
 
@@ -36,3 +37,21 @@ The data in event.options is made available to the shell scripts in two ways:
 
 Simple data types (strings and numbers) are passed on as they are.
 Complex data types (objects, arrays, etc) are encoded in JSON format.
+
+## Node Script
+
+Create a .js file that exports a function handler for the hook.
+NOTE: the function must return a promise that resolves a hook event object just like a normal hook would
+
+The handler function is passed 2 arguments:
+1. __S__: the ServerlessPlugin Class
+2. __evt__: the hook event object
+
+For example:
+```
+module.exports = function(S, evt) {
+  // your hook code here
+
+  return Promise.resolve(evt);
+};
+```


### PR DESCRIPTION
Node script support can give the user more flexibility with hooks by passing in the `S` plugin instance and the full `evt` object. This can be a handy way of creating hooks without needing to create a whole plugin to access the serverless api.
